### PR TITLE
Reject invalid JSON as field default value

### DIFF
--- a/packages/shiro-compiler/src/model/index.ts
+++ b/packages/shiro-compiler/src/model/index.ts
@@ -33,6 +33,7 @@ import {
   convertToCamelCase,
   convertToSnakeCase,
   getQuerySymbol,
+  isObject,
   splitQuery,
 } from '@/src/utils/helpers';
 import { compileQueryInput } from '@/src/utils/index';
@@ -397,7 +398,17 @@ const getFieldStatement = (
         ? `'${field.defaultValue}'`
         : field.defaultValue;
     if (symbol) value = `(${parseFieldExpression(model, 'to', symbol.value as string)})`;
-    if (field.type === 'json') value = `'${JSON.stringify(field.defaultValue)}'`;
+    if (field.type === 'json') {
+      if (!isObject(field.defaultValue)) {
+        throw new RoninError({
+          message: `The default value of JSON field "${field.slug}" must be an object.`,
+          code: 'INVALID_MODEL_VALUE',
+          fields: ['fields'],
+        });
+      }
+
+      value = `'${JSON.stringify(field.defaultValue)}'`;
+    }
 
     statement += ` DEFAULT ${value}`;
   }
@@ -964,7 +975,7 @@ export const transformMetaQuery = (
         throw new RoninError({
           message: `When ${actionReadable} ${PLURAL_MODEL_ENTITIES[entity]}, at least one field must be provided.`,
           code: 'INVALID_MODEL_VALUE',
-          fields: ['fields'],
+          fields: [PLURAL_MODEL_ENTITIES[entity]],
         });
       }
 

--- a/packages/shiro-compiler/src/model/index.ts
+++ b/packages/shiro-compiler/src/model/index.ts
@@ -403,7 +403,7 @@ const getFieldStatement = (
         throw new RoninError({
           message: `The default value of JSON field "${field.slug}" must be an object.`,
           code: 'INVALID_MODEL_VALUE',
-          fields: ['fields'],
+          field: 'fields',
         });
       }
 
@@ -975,7 +975,7 @@ export const transformMetaQuery = (
         throw new RoninError({
           message: `When ${actionReadable} ${PLURAL_MODEL_ENTITIES[entity]}, at least one field must be provided.`,
           code: 'INVALID_MODEL_VALUE',
-          fields: [PLURAL_MODEL_ENTITIES[entity]],
+          field: PLURAL_MODEL_ENTITIES[entity],
         });
       }
 

--- a/packages/shiro-compiler/tests/meta.test.ts
+++ b/packages/shiro-compiler/tests/meta.test.ts
@@ -884,7 +884,7 @@ test('create new field with default value (invalid json)', async () => {
     'The default value of JSON field "settings" must be an object.',
   );
   expect(error).toHaveProperty('code', 'INVALID_MODEL_VALUE');
-  expect(error).toHaveProperty('fields', ['fields']);
+  expect(error).toHaveProperty('field', 'fields');
 });
 
 // Ensure that, if the `slug` of a field changes during a model update, an `ALTER TABLE`
@@ -1782,7 +1782,7 @@ test('try to create new index without fields', () => {
     'When creating indexes, at least one field must be provided.',
   );
   expect(error).toHaveProperty('code', 'INVALID_MODEL_VALUE');
-  expect(error).toHaveProperty('fields', ['indexes']);
+  expect(error).toHaveProperty('field', 'indexes');
 });
 
 test('try to create new index with non-existent field', () => {

--- a/packages/shiro-compiler/tests/meta.test.ts
+++ b/packages/shiro-compiler/tests/meta.test.ts
@@ -845,6 +845,48 @@ test('create new field with default value (json)', async () => {
   });
 });
 
+// Assert that invalid objects are being rejected as default values of JSON fields.
+test('create new field with default value (invalid json)', async () => {
+  const field: ModelField = {
+    type: 'json',
+    slug: 'settings',
+    defaultValue: 'test',
+  };
+
+  const queries: Array<Query> = [
+    {
+      alter: {
+        model: 'account',
+        create: {
+          field,
+        },
+      },
+    },
+  ];
+
+  const models: Array<Model> = [
+    {
+      slug: 'account',
+    },
+  ];
+
+  let error: Error | undefined;
+
+  try {
+    new Transaction(queries, { models });
+  } catch (err) {
+    error = err as Error;
+  }
+
+  expect(error).toBeInstanceOf(RoninError);
+  expect(error).toHaveProperty(
+    'message',
+    'The default value of JSON field "settings" must be an object.',
+  );
+  expect(error).toHaveProperty('code', 'INVALID_MODEL_VALUE');
+  expect(error).toHaveProperty('fields', ['fields']);
+});
+
 // Ensure that, if the `slug` of a field changes during a model update, an `ALTER TABLE`
 // statement is generated for it.
 test('alter existing field (slug)', () => {
@@ -1740,6 +1782,7 @@ test('try to create new index without fields', () => {
     'When creating indexes, at least one field must be provided.',
   );
   expect(error).toHaveProperty('code', 'INVALID_MODEL_VALUE');
+  expect(error).toHaveProperty('fields', ['indexes']);
 });
 
 test('try to create new index with non-existent field', () => {

--- a/packages/shiro-compiler/tests/meta.test.ts
+++ b/packages/shiro-compiler/tests/meta.test.ts
@@ -846,7 +846,7 @@ test('create new field with default value (json)', async () => {
 });
 
 // Assert that invalid objects are being rejected as default values of JSON fields.
-test('create new field with default value (invalid json)', async () => {
+test('create new field with default value (invalid json)', () => {
   const field: ModelField = {
     type: 'json',
     slug: 'settings',


### PR DESCRIPTION
This change ensures that it will no longer be possible to provide invalid JSON as the default value of a JSON field.