### PR TITLE
Added `models` option

### DIFF
--- a/packages/shiro-orm/src/queries.ts
+++ b/packages/shiro-orm/src/queries.ts
@@ -98,6 +98,7 @@ export const runQueries = async <T extends ResultRecord>(
       ? options.models
       : (Object.values(options.models) as unknown as Array<Model>);
 
+    const { queries } = operations.default;
     transaction = new Transaction(queries, { models });
 
     delete operations.default.queries;

--- a/packages/shiro-orm/src/types/utils.ts
+++ b/packages/shiro-orm/src/types/utils.ts
@@ -43,6 +43,9 @@ export interface QueryHandlerOptions {
    * provide the desired database name here.
    */
   database?: string;
+
+  /** A list of models defined during development. */
+  models?: Record<string, Record<string, unknown>> | Array<Model>;
 }
 
 /**


### PR DESCRIPTION
This change makes it possible to pass a `models` option to Shiro, which, when provided, ensures that queries are automatically converted into SQL using the compiler.